### PR TITLE
vol_f and zone_id are not required in the announcement model v0.1.8

### DIFF
--- a/pyamplipi/models.py
+++ b/pyamplipi/models.py
@@ -168,8 +168,8 @@ class PresetUpdate(BaseModel):
 class Announcement(BaseModel):
     media: str
     vol: Optional[int]
-    vol_f: float
-    source_id: int
+    vol_f: Optional[float]
+    source_id: Optional[int]
     zones: Optional[List[int]]
     groups: Optional[List[int]]
 


### PR DESCRIPTION
closes #7